### PR TITLE
Update examples in README.md and sh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ echo "\e[41m****Deployment Finished Site Enabled and tested****";
 
 > **Host: needs your real domain name**.
 ```bash
-status_code=$(curl -kI --header 'Host: cbi2cs52sas1djs9.mojostratus.io' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
+status_code=$(curl -kI --header 'Host: {yourhost}.com' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
 ```
 
 > Two type of responses expected, either echo that task is completed or message that something went wrong and needs investigated. We will execute two Magento 2 cron tasks to Reindex all Invalid indexers and updated all views. Also, we will start Cron container and Cron tasks defined in the Stratus panel.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ echo "\e[41m****Deployment Finished Site Enabled and tested****";
 
 > In next block we will test using CURL method if store is actually giving 200 OK response or not. This also warms caches. 
 
-> **Host: needs your real domain name**.
+> **Host: needs your real domain name, replace "{yourhost}.com" with your URL, for example cbi2cs52sas1djs9.mojostratus.io"**.
 ```bash
 status_code=$(curl -kI --header 'Host: {yourhost}.com' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
 ```
@@ -115,7 +115,7 @@ Recommended Bash script for Magento 2 deployments on Mojo Stratus Platform
 
 > Maintenance mode is needed for now because the reinit command will split brain php-fpm code until all complete. A fix for this is being actively worked on will be released soon.
 ```bash
-php bin/magento maintenance:enable;
+/usr/local/bin/php bin/magento maintenance:enable;
 ```
 
 > If you enabled one or more modules, then you will need to run magento setup:upgrade to update the database schema. By default, magento setup:upgrade clears compiled code and the cache. Typically, you use magento setup:upgrade to update components and each component can require different compiled classes.
@@ -163,6 +163,11 @@ echo "\e[41m****Flushing Magento, Varnish, Redis and CloudFront CDN cache at thi
 /usr/local/bin/php -dmemory_limit=20000M bin/magento cache:flush;
 ```
 
+> Flushes only the PHP OpCache.
+```bash
+/usr/share/stratus/cli cache.opcache.flush;
+```
+
 > Clears Cloudfront CDN cache only. This can take up to 15 minutes.
 ```bash
 /usr/share/stratus/cli cache.cloudfront.invalidate;
@@ -180,7 +185,7 @@ redis-cli -h redis flushall && redis-cli -h redis-config-cache -p 6381 flushall;
 
 > Disable maintenance mode command.
 ```bash
-php bin/magento maintenance:disable;
+/usr/local/bin/php bin/magento maintenance:disable;
 ```
 
 > Description message that deployment is being done and that certain testing starts.
@@ -190,9 +195,9 @@ echo "\e[41m****Deployment Finished Site Enabled and tested****";
 
 > In next block we will test using CURL method if store is actually giving 200 OK response or not. This also warms caches. 
 
-> **Host: needs your real domain name**.
+> **Host: needs your real domain name, replace "{yourhost}.com" with your URL, for example cbi2cs52sas1djs9.mojostratus.io"**.
 ```bash
-status_code=$(curl -kI --header 'Host: cbi2cs52sas1djs9.mojostratus.io' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
+status_code=$(curl -kI --header 'Host: {yourhost}.com' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
 ```
 
 > Two type of responses expected, either echo that task is completed or message that something went wrong and needs investigated. We will execute two Magento 2 cron tasks to Reindex all Invalid indexers and updated all views. Also, we will start Cron container and Cron tasks defined in the Stratus panel.

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ For old deployment example navigate down or click https://github.com/magemojo/mo
 
 > If you enabled one or more modules, then you will need to run magento setup:upgrade to update the database schema. By default, magento setup:upgrade clears compiled code and the cache. Typically, you use magento setup:upgrade to update components and each component can require different compiled classes.
 ```bash
-/usr/local/bin/php -dmemory_limit=8000M bin/magento setup:upgrade;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento setup:upgrade;
 ```
 To prevent generated files from being deleted, please update command with --keep-generated flag
 
 > The command setup:di:compile command generates the contents of the var/di folder in Magento <2.2 and generated for Magento >= 2.2 and 2.3+. According to the Magento docs this is more an optimization step (that is, optimized code generation of interceptors). It's not mandatory to run setup:di:compile command everytime but if you have done any code change specially with factory methods, proxy, add plugins or any code compilation then you must need to run this command.
 ```bash
-/usr/local/bin/php -dmemory_limit=8000M bin/magento setup:di:compile;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento setup:di:compile;
 ```
 
 > The class loader used while developing the application is optimized to find new and changed classes. In production servers, PHP files should never change, unless a new application version is deployed. That's why you can optimize Composer's autoloader to scan the entire application once and build a "class map", which is a big array of the locations of all the classes and it's stored in vendor/composer/autoload_classmap.php.
 ```bash
-/usr/local/bin/php -dmemory_limit=8000M /usr/local/bin/composer dump-autoload --no-dev --optimize --apcu;
+/usr/local/bin/php -dmemory_limit=20000M /usr/local/bin/composer dump-autoload --no-dev --optimize --apcu;
 ```
 
 > This is the command you'd run before deploying to production mode. If you're running in default or developer mode, those files should be generating for you automatically. Magento 2 requires deployment of static assets such as CSS/JS based on your theme.  Deploy via your panel using these steps.  This may take some time to complete.
@@ -49,12 +49,12 @@ echo "\e[41m****Flushing Magento, Varnish, Redis and CloudFront CDN cache at thi
 
 > Cleaning a cache type deletes all items from enabled Magento cache types only. In other words, this option does not affect other processes or applications because it cleans only the cache that Magento uses. Magento 2.4.2 users can remove cache:clean from their deployment scripts since latest setup:upgrade flushes caches when executed.
 ```bash
-/usr/local/bin/php -dmemory_limit=8000M bin/magento cache:clean;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:clean;
 ```
 
 > Flushing a cache type purges the cache storage, which might affect other processes applications that are using the same storage. Magento 2.4.2 users can remove cache:flush from their deployment scripts since latest setup:upgrade flushes caches when executed.
 ```bash
-/usr/local/bin/php -dmemory_limit=8000M bin/magento cache:flush;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:flush;
 ```
 
 > Flushes only the PHP OpCache.
@@ -75,58 +75,6 @@ echo "\e[41m****Flushing Magento, Varnish, Redis and CloudFront CDN cache at thi
 > This line purges Redis Page and Full Page cache (if Varnish not used). The Redis Session instance is not flushed.
 ```bash
 redis-cli -h redis flushall && redis-cli -h redis-config-cache -p 6381 flushall;
-```
-
-> Description message that deployment is being done and that certain testing starts.
-```bash
-echo "\e[41m****Deployment Finished Site Enabled and tested****";
-```
-
-> In next block we will test using CURL method if store is actually giving 200 OK response or not. This also warms caches. 
-
-> **Host: needs your real domain name**.
-```bash
-status_code=$(curl -kI --header 'Host: cbi2cs52sas1djs9.mojostratus.io' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
-```
-
-> Two type of responses expected, either echo that task is completed or message that something went wrong and needs investigated. We will execute two Magento 2 cron tasks to Reindex all Invalid indexers and updated all views. Also, we will start Cron container and Cron tasks defined in the Stratus panel.
-```bash
-if [[ "$status_code" -ne 200 ]] ; then
-  echo "Site not active $status_code please push script again"
-else
-  echo "\e[41m****Beginning Indexing****";
-  n98-magerun2 sys:cron:run indexer_reindex_all_invalid;
-  n98-magerun2 sys:cron:run indexer_update_all_views;
-  /usr/share/stratus/cli crons.start;
-  
-  echo "\e[41m****Activity Completed please visit store and test****";
-fi
-/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:clean;
-```
-
-> Flushing a cache type purges the cache storage, which might affect other processes applications that are using the same storage.
-```bash
-/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:flush;
-```
-
-> Clears Cloudfront CDN cache only. This can take up to 15 minutes.
-```bash
-/usr/share/stratus/cli cache.cloudfront.invalidate;
-```
-
-> This command purges Varnish cache entirely.
-```bash
-/usr/share/stratus/cli cache.varnish.clear;
-```
-
-> This line purges Redis Page and Full Page cache (if Varnish not used). The Redis Session instance is not flushed.
-```bash
-redis-cli -h redis flushall && redis-cli -h redis-config-cache -p 6381 flushall;
-```
-
-> Disable maintenance mode command.
-```bash
-php bin/magento maintenance:disable;
 ```
 
 > Description message that deployment is being done and that certain testing starts.

--- a/deploy-zdd.sh
+++ b/deploy-zdd.sh
@@ -1,15 +1,15 @@
 /usr/share/stratus/cli crons.stop;
 ### PUSH NEW CODE/UPDATES HERE
 ### git pull etc
-/usr/local/bin/php -dmemory_limit=8000M bin/magento setup:upgrade;
-/usr/local/bin/php -dmemory_limit=8000M bin/magento setup:di:compile;
-/usr/local/bin/php -dmemory_limit=8000M /usr/local/bin/composer dump-autoload --no-dev --optimize --apcu;
-/usr/local/bin/php -dmemory_limit=8000M bin/magento setup:static-content:deploy --jobs=$(nproc);
+/usr/local/bin/php -dmemory_limit=20000M bin/magento setup:upgrade;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento setup:di:compile;
+/usr/local/bin/php -dmemory_limit=20000M /usr/local/bin/composer dump-autoload --no-dev --optimize --apcu;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento setup:static-content:deploy --jobs=$(nproc);
 /usr/share/stratus/cli zerodowntime.init;
 /usr/share/stratus/cli zerodowntime.switch;
 echo "\e[41m****Flushing Magento, Varnish, Redis and CloudFront CDN cache at this stage****";
-/usr/local/bin/php -dmemory_limit=8000M bin/magento cache:clean;
-/usr/local/bin/php -dmemory_limit=8000M bin/magento cache:flush;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:clean;
+/usr/local/bin/php -dmemory_limit=20000M bin/magento cache:flush;
 /usr/share/stratus/cli cache.opcache.flush;
 /usr/share/stratus/cli cache.cloudfront.invalidate;
 /usr/share/stratus/cli cache.varnish.clear;
@@ -20,6 +20,9 @@ if [[ "$status_code" -ne 200 ]] ; then
   echo "Site not active $status_code please push script again"
 else
   echo "\e[41m****Beginning Indexing****";
-n98-magerun2 sys:cron:run indexer_reindex_all_invalid;
-n98-magerun2 sys:cron:run indexer_update_all_views;
-/usr/share/stratus/cli crons.start
+  n98-magerun2 sys:cron:run indexer_reindex_all_invalid;
+  n98-magerun2 sys:cron:run indexer_update_all_views;
+  /usr/share/stratus/cli crons.start
+
+  echo "\e[41m****Activity Completed please visit store and test****";
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 /usr/share/stratus/cli crons.stop;
-php bin/magento maintenance:enable;
+/usr/local/bin/php bin/magento maintenance:enable;
 /usr/local/bin/php -dmemory_limit=20000M bin/magento setup:upgrade;
 /usr/local/bin/php -dmemory_limit=20000M bin/magento setup:di:compile;
 /usr/local/bin/php -dmemory_limit=20000M /usr/local/bin/composer dump-autoload --no-dev --optimize --apcu;
@@ -13,16 +13,16 @@ echo "\e[41m****Flushing Magento, Varnish, Redis and CloudFront CDN cache at thi
 /usr/share/stratus/cli cache.cloudfront.invalidate;
 /usr/share/stratus/cli cache.varnish.clear;
 redis-cli -h redis flushall && redis-cli -h redis-config-cache -p 6381 flushall;
-php bin/magento maintenance:disable;
+/usr/local/bin/php bin/magento maintenance:disable;
 echo "\e[41m****Deployment Finished Site Enabled and tested****";
-status_code=$(curl -kI --header 'Host: cbi2cs52sas1djs9.mojostratus.io' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
+status_code=$(curl -kI --header 'Host: {yourhost}.com' --write-out %{http_code} --silent --output /dev/null 'https://nginx/')
 if [[ "$status_code" -ne 200 ]] ; then
   echo "Site not active $status_code please push script again"
 else
   echo "\e[41m****Beginning Indexing****";
-n98-magerun2 sys:cron:run indexer_reindex_all_invalid;
-n98-magerun2 sys:cron:run indexer_update_all_views;
-/usr/share/stratus/cli crons.start;
+  n98-magerun2 sys:cron:run indexer_reindex_all_invalid;
+  n98-magerun2 sys:cron:run indexer_update_all_views;
+  /usr/share/stratus/cli crons.start;
 
-echo "\e[41m****Activity Completed please visit store and test****";
+  echo "\e[41m****Activity Completed please visit store and test****";
 fi


### PR DESCRIPTION
Hello Friends! 
While reading your documentation and examples of the scripts I have mentioned a few things which would be great to improve/update - so I have created this PR to help you :) 

I am still not sure about a few things: 

1. why do we need to execute the `bin/magento cache:clean` right before the `bin/magento cache:flush` in both deployment scenarios? The bin/magento cache:flush should be enough, but please let me know if I am missing something.
2. why do we need to execute the `/usr/share/stratus/cli cache.opcache.flush;` in the **Zero Downtime Deploy** scenario if the following is mentioned in your docs _"Clearing the PHP Opcache is not necessary since new PHP-FPM containers are created."_ on https://magemojo.com/kb/best-practices/zero-downtime-deploys/ 

It would be great to update examples in the docs on https://magemojo.com/kb/,  https://training.magemojo.com/courses/take/mastering-webscale-stratus/lessons/18993823-deployment-process, https://training.magemojo.com/courses/take/mastering-webscale-stratus/lessons/18993824-zero-downtime-deployment as well after merging this PR. 